### PR TITLE
i13316 | Plugin require_dependency seems to not comply with latest easyredmine

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'redmine'
 
-require_dependency 'redmine_slack/listener'
+require_dependency __dir__ + '/lib/redmine_slack/listener'
 
 Redmine::Plugin.register :redmine_slack do
 	name 'Redmine Slack'


### PR DESCRIPTION
After dropping it in favor of a simple require_relative (as it is used in other easy plugins), the plugin works seamlessly.