### PR TITLE
Use ActiveSupport::Reloader.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -23,7 +23,7 @@ Redmine::Plugin.register :redmine_slack do
 		:partial => 'settings/slack_settings'
 end
 
-ActionDispatch::Callbacks.to_prepare do
+ActiveSupport::Reloader.to_prepare do
 	require_dependency 'issue'
 	unless Issue.included_modules.include? RedmineSlack::IssuePatch
 		Issue.send(:include, RedmineSlack::IssuePatch)


### PR DESCRIPTION
`ActionDispatch::Callbacks` was deprecated here:
https://github.com/rails/rails/commit/3f2b7d60a52ffb2ad2d4fcf889c06b631db1946b#diff-1c13a97300266bc1689b138c5d3bb95fL10

This PR is using the correct class.